### PR TITLE
[COOK-3666] add an  `upgrade` param to `cpan_module`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ Optionally, installation can forced with the 'force' parameter.
 cpan_module 'App::Munchies'
   force true
 end
+```
 
+To ensure that latest available package is installed:
+
+```ruby
+cpan_module 'App::Munchies'
+  upgrade true
+end
+```
 
 License & Authors
 -----------------

--- a/definitions/cpan_module.rb
+++ b/definitions/cpan_module.rb
@@ -19,18 +19,21 @@
 
 define :cpan_module, :force => nil, :upgrade => false do
   execute "install-#{params[:name]}" do
-    if params[:force]
-      command "#{node['perl']['cpanm']['path']} --force --notest #{params[:name]}"
-    else
-      command "#{node['perl']['cpanm']['path']} --notest #{params[:name]}"
-    end
+    flags = %w[ --notest ]
+    flags << '--force' if params[:force]
+    flags << (
+      if params[:upgrade] then 
+	'--skip-installed'
+      else 
+	'--skip-satisfied'
+      end
+    )
+    command "#{node[:perl][:cpanm][:path]} #{flags.join(' ')} #{params[:name]}" 
     root_dir = (node['platform'] == "mac_os_x") ? "/var/root" : "/root"
     cwd root_dir
     # Will create working dir on /root/.cpanm (or /var/root)
     environment "HOME" => root_dir
     path [ "/usr/local/bin", "/usr/bin", "/bin" ]
-    unless params[:upgrade]
-      not_if "perl -m#{params[:name]} -e ''" 
-    end
+    
   end
 end

--- a/definitions/cpan_module.rb
+++ b/definitions/cpan_module.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-define :cpan_module, :force => nil do
+define :cpan_module, :force => nil, :upgrade => false do
   execute "install-#{params[:name]}" do
     if params[:force]
       command "#{node['perl']['cpanm']['path']} --force --notest #{params[:name]}"
@@ -29,6 +29,8 @@ define :cpan_module, :force => nil do
     # Will create working dir on /root/.cpanm (or /var/root)
     environment "HOME" => root_dir
     path [ "/usr/local/bin", "/usr/bin", "/bin" ]
-    not_if "perl -m#{params[:name]} -e ''"
+    unless params[:upgrade]
+      not_if "perl -m#{params[:name]} -e ''" 
+    end
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3666

`cpan_module` currently doesn't provide a way to ensure that 
the given Perl module installed on the system is the latest available. 
The `package` resource has an `:upgrade` action: 
`cpan_module` would benefit from having one as well.

Usually, `cpanm` will automatically upgrade the module if already installed .
While `cpan_module` calls `cpanm`, it uses an idempotency check 
via `perl -m#{module_name}` and if a (possibly outdated) version of the package
happens to be already on the system (perhaps because it was provided by
a an RPM/DEB version), it will never have a chance to be updated.

This commit causes the idempotency check to be handled directly by `cpanm`
when `upgrade true` is passed.

