### PR TITLE
[COOK-4725] Use windows_path to set the PATH

### DIFF
--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -54,6 +54,6 @@ execute 'Install StrawberryPerl' do
   not_if { File.exists?("#{node['perl']['install_dir']}\\perl\\bin\\perl.exe") }
 end
 
-execute 'Add Perl to PATH' do
-  command "setx /M path \"#{node['perl']['install_dir']}perl\\bin;%path%\""
+windows_path "#{node['perl']['install_dir']}perl\\bin" do
+  action :add
 end


### PR DESCRIPTION
Using `execute` to alter the SYSTEM PATH has lots of negative side effects:
1. It doesn't have a guard, so it adds the PATH every time the cookbook is
   run. 2. It clobbers any previously run `windows_path` because the environment
   hasn't been reloaded.

This closes https://tickets.opscode.com/browse/COOK-4725

I have signed the CLA.
