### PR TITLE
updated cpanm to new redirect location

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,7 +50,7 @@ else
   default['perl']['packages'] = %w(perl libperl-dev)
 end
 
-default['perl']['cpanm']['url'] = 'https://raw.github.com/miyagawa/cpanminus/1.6922/cpanm'
+default['perl']['cpanm']['url'] = 'https://raw.githubusercontent.com/miyagawa/cpanminus/1.6922/cpanm'
 default['perl']['cpanm']['checksum'] = 'cb35d3f1ac8f59c1458e1f67308c9caa4959f3912dfeac603b8aff29c6fe643d'
 default['perl']['cpanm']['path'] = '/usr/local/bin/cpanm'
 


### PR DESCRIPTION
Addressing issue #22 

Updated default['perl']['cpanm']['url'] to use new redirected url