### PR TITLE
Fixing version detection in Perl modules

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,7 +20,7 @@ module PerlCookbook
       return mod_ver if mod_ver.empty?
       # remove leading v and convert underscores to dots since gems parses them wrong
       mod_ver.gsub!(/v_?(\d)/, '\\1')
-      mod_ver.gsub!(/_/, '.')
+      mod_ver.tr!('_', '.')
       # in the event that this command outputs whatever it feels like, only keep the first vers number!
       version_match = /(^[0-9.]*)/.match(mod_ver)
       version_match[0]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,8 @@ module PerlCookbook
       mod_ver = mod_ver_cmd.stdout
       return mod_ver if mod_ver.empty?
       # remove leading v and convert underscores to dots since gems parses them wrong
-      mod_ver.gsub!(/v_/, 'v' => 3, '_' => '.')
+      mod_ver.gsub!(/v_?(\d)/, '\\1')
+      mod_ver.gsub!(/_/, '.')
       # in the event that this command outputs whatever it feels like, only keep the first vers number!
       version_match = /(^[0-9.]*)/.match(mod_ver)
       version_match[0]


### PR DESCRIPTION
### Description

Fixing the removal of the leading `v` and the conversion of the underscores to dots in Perl module versions.

The test case where it didn’t work before is DateTime::Format::RFC3339 module which uses “v1.2.0” for its version.