### PR TITLE
Do not use an explicit owner and group

### DIFF
--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -28,8 +28,6 @@ if tempdir.nil? || tempdir == ''
   directory tempdir do
     action :create
     inherits true
-    owner 'administrator'
-    group 'administrators'
   end
 end
 
@@ -37,16 +35,11 @@ directory node['perl']['install_dir'] do
   action :create
   recursive true
   inherits true
-  owner 'administrator'
-  group 'administrators'
 end
 
 remote_file "#{tempdir}\\#{installer}" do
   source "http://strawberryperl.com/download/#{node['perl']['maj_version']}.#{node['perl']['min_version']}.#{node['perl']['sub_version']}/#{installer}"
   action :create
-  owner 'administrator'
-  group 'administrators'
-  mode '0774'
 end
 
 execute 'Install StrawberryPerl' do


### PR DESCRIPTION
This enables the cookbook to run on windows machines where the administrator account is not named `Administrator`. Not using an explicit owner and group does not break the installation as it will just inherit the rights, which is actually the default behaviour you would expect.

Besides that it’s advised (for security reasons) to rename your administrator account, this poses a real problem on Azure.

Azure does not allow you to create a Windows VM with an account named `Administrator`. So you are required to choose a different name for the administrator account which prevents this cookbook from being able to run correctly.
