### PR TITLE
Allow people to suppress the cpanm diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The cookbook ships with a sane set of platform specific attributes for installin
 - `node['perl']['cpanm']['checksum']` - checksum for the above remote file (*nix only)
 - `node['perl']['version']` - version of perl to install. (windows only)
 - `node['perl']['cpanm']['path']` - The path to the cpanm binary. On *nix systems this is where the file will be installed. On Windows it's part of Strawberry Perl so no additional installation is required.
+- `node['perl']['cpanm']['suppress_diff']` - Whether or not to suppress the diff of the cpanm file.
 
 ## Resources
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,7 @@ end
 
 default['perl']['cpanm']['url'] = 'https://raw.githubusercontent.com/miyagawa/cpanminus/1.7043/cpanm'
 default['perl']['cpanm']['checksum'] = 'd2221f1adb956591fa43cd61d0846b961be1fffa222210f097bfd472a11e0539'
+default['perl']['cpanm']['suppress_diff'] = false
 
 default['perl']['cpanm']['path'] = if node['platform_family'] == 'windows'
                                      'C:\\strawberry\\perl\\bin\\cpanm'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,5 +40,6 @@ else
     owner 'root'
     group node['root_group']
     mode '0755'
+    sensitive cpanm['suppress_diff']
   end
 end


### PR DESCRIPTION
### Description

My test kitchen output for things that use this keeps getting huge. So, I'd like to supress the diff. Pretty straightfoward diff, though I'm not sure what I'd call the parameter.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
