### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- resolved cookstyle error: resources/cpan_module.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 7.1.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/cpan_module.rb
+++ b/resources/cpan_module.rb
@@ -1,4 +1,5 @@
 provides :cpan_module
+unified_mode true
 
 property :module_name, String, name_property: true
 property :force, [true, false], default: false


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/cpan_module.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)